### PR TITLE
Bring the README up to the memoized API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 This library deduplicates signals received from external systems, by remembering which ones have already been processed.
 
-It is based on two main concepts:
+It is based on three concepts:
 
 - `id`: The unique identifier of the signal
 - `processorId`: The unique identifier of the system processing the signal
+- `Memoized`: The type of the value produced by processing the signal, which is stored and handed back to duplicates
 
 It works across multiple nodes sharing the same `processorId`. The persistence is based on [DynamoDb](https://aws.amazon.com/dynamodb/) and its strong consistency write capability. The same concept can be applied to [Apache Cassandra](http://cassandra.apache.org/) or any other similar database that provides these two features:
 
@@ -22,7 +23,23 @@ We need to know the max amount of time the process will take (`maxProcessingTime
 
 ## How does it work
 
-It is based on the two phase commit strategy. It records when the processor starts to process a signal and when it completes it. It provides a `protect` method that wraps the effect of signal processing to guarantee that it will happen only once for each `processorId`.
+It is based on the two phase commit strategy. It records when the processor starts to process a signal and when it completes it. It provides a `protect` method that wraps the effect of signal processing to guarantee that it will happen only once for each `processorId`:
+
+```scala
+trait Mnemosyne[F[_], Id, ProcessorId, Memoized] {
+  def tryStartProcess(id: Id): F[Outcome[F, Memoized]]
+  def protect(id: Id, fa: F[Memoized]): F[Memoized]
+}
+```
+
+`protect` returns the value the effect produced, not `Unit`. On a first attempt it runs `fa` and stores the result; on a duplicate it runs nothing and returns the stored result. That matters whenever the effect produces something the caller still needs after deduplication kicks in — the message id an email provider hands back, for instance: the duplicate must not send the email again, but it does still need that id.
+
+If you want the outcome rather than the value, `tryStartProcess` exposes it directly:
+
+- `Outcome.New(completeProcess)`: nothing has run yet. Do the work, then hand the result to `completeProcess` so it is stored.
+- `Outcome.Duplicate(value)`: it has run before, and `value` is what it produced.
+
+Use `Memoized = Unit` if the effect has no result worth keeping.
 
 The DynamoDb table has this structure:
 
@@ -31,8 +48,9 @@ The DynamoDb table has this structure:
 - `startedAt`: N - The datetime the signal has started to be processed
 - `completedAt`: N - The datetime when the signal has been completed
 - `expiresOn`: N - The datetime when the signal process will expires
+- `memoized`: The value produced by the process, encoded according to the `Memoized` type. Absent until the process completes
 
-Each time a processor with a given `processorId` attempt to process a signal identified by `id`, it updates or writes on the table a record with `id`, `processorId`, `startedAt`. If the record with given `id` and `processorId` was already present, its value is returned to the library otherwise nothing is returned. After the process has run successfully, the library mark it as completed by storing the `completedAt` and the `expiresOn` fields.
+Each time a processor with a given `processorId` attempt to process a signal identified by `id`, it updates or writes on the table a record with `id`, `processorId`, `startedAt`. If the record with given `id` and `processorId` was already present, its value is returned to the library otherwise nothing is returned. After the process has run successfully, the library marks it as completed by storing the `completedAt`, `expiresOn` and `memoized` fields.
 
 The `expiresOn` allows to clean up old data and re-run duplicate after some time.
 
@@ -43,8 +61,4 @@ When the library attempts to start a process, these scenarios can happen:
 3) The signal has timeout processing (`completedAt` is absent and `startedAt` + `processingTime` is in the past)
 4) The signal is still being processed (`completedAt` is absent and `startedAt` + `processingTime` is in the future)
 
-In cases (1) and (3) the library allows the signal to be processed. In case (2) it does not, as the signal has already been handled. In case (4) it waits for the other attempt to either complete or time out before deciding.
-
-## Terraform
-
-An [example terraform file](example.tf) is provided for provisioning the backing database with DynamoDB.
+In cases (1) and (3) the library allows the signal to be processed. In case (2) it does not, as the signal has already been handled — it returns the memoized value instead. In case (4) it waits for the other attempt to either complete or time out before deciding.

--- a/modules/core/src/main/scala/mnemosyne/Mnemosyne.scala
+++ b/modules/core/src/main/scala/mnemosyne/Mnemosyne.scala
@@ -48,10 +48,10 @@ trait Mnemosyne[F[_], Id, ProcessorId, Memoized] {
     * ```
     * tryStartProcess(id)
     *   .flatMap {
-    *     case Outcome.New(markAsComplete) =>
-    *       doYourStuff.flatTap(_ => markAsComplete)
-    *     case Outcome.Duplicate() =>
-    *       dontDoYourStuff
+    *     case Outcome.New(completeProcess) =>
+    *       doYourStuff.flatTap(completeProcess)
+    *     case Outcome.Duplicate(value) =>
+    *       value.pure[F]
     *   }
     * ```
     *


### PR DESCRIPTION
After #36 the README still described the previous library: no `Memoized` anywhere, no `memoized` column in the table layout, and `protect` implicitly returning nothing.

## Changes

- Documents the trait as it is now, and states that `protect` returns the value rather than `Unit` — with the reason it matters: a duplicate must not repeat the effect but often still needs what the effect produced. The example is an email provider returning a message id: don't send the email twice, but the caller still needs that id, and it isn't recoverable anywhere else.
- Describes `Outcome.New(completeProcess)` and `Outcome.Duplicate(value)` for callers who want the outcome instead of the value.
- Adds `memoized` to the table layout, and to the list of fields written on completion.
- Case (2) now says it returns the memoized value rather than just declining to process.
- Notes `Memoized = Unit` for effects with no result worth keeping.

## Also

**Drops the Terraform section.** #36 deleted `example.tf`, so the link had been pointing at a file that no longer exists.

**Fixes the scaladoc on `tryStartProcess`**, whose example still matched `Outcome.Duplicate()` with no value — it wouldn't compile against the current type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)